### PR TITLE
Expose Hash, Sign, VerifySignature and VerifyHashSignature

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -21,7 +21,7 @@ func VerifySignature(input []byte, signature []byte, sigalg uint32, key crypto.P
 }
 
 // VerifyHashSignature takes a signature, the digest of a signed MAR block, a hash algorithm and a public
-// key and return nil if a valid signature is found, or an error if it isn't
+// key and returns nil if a valid signature is found, or an error if it isn't
 func VerifyHashSignature(signature []byte, digest []byte, hashAlg crypto.Hash, key crypto.PublicKey) error {
 	switch key.(type) {
 	case *rsa.PublicKey:

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,6 +1,8 @@
 package mar
 
 import (
+	"crypto/dsa"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"log"
@@ -36,5 +38,25 @@ func TestFirefoxKeys(t *testing.T) {
 	}
 	if len(validKeys) != 1 || validKeys[0] != "unit_test" {
 		t.Fatal("expected signature from 'unit_test' key but didn't get one")
+	}
+}
+
+func TestBadKey(t *testing.T) {
+	var priv dsa.PrivateKey
+	params := &priv.Parameters
+	err := dsa.GenerateParameters(params, rand.Reader, dsa.L1024N160)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = dsa.GenerateKey(&priv, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = VerifySignature([]byte("0000"), []byte("0000"), SigAlgEcdsaP384Sha384, priv.PublicKey)
+	if err == nil {
+		t.Fatal("expected to fail with invalid dsa key type but succeeded")
+	}
+	if err.Error() != "unknown public key type dsa.PublicKey" {
+		t.Fatalf("expect to fail with invalid dsa key type but failed with: %v", err)
 	}
 }


### PR DESCRIPTION
This patch refactors some of the internal logic to expose public functions that can be used outside of a MAR file.